### PR TITLE
Muu 187

### DIFF
--- a/src/clients/artikkelit/artikkelit.html
+++ b/src/clients/artikkelit/artikkelit.html
@@ -279,7 +279,7 @@
               <div id="artikkelin-arvostelu-tyyppi-wrap">
                 <div class="full-width">
                   <div class="Input">
-                    <label for="artikkelin-arvostelu-tyyppi">Arvostelu tyyppi:</label>
+                    <label for="artikkelin-arvostelu-tyyppi">Arvostelun tyyppi:</label>
                     <input type="text" id="artikkelin-arvostelu-tyyppi" name="artikkelin-arvostelu-tyyppi"
                     list="artikkelin-luokitus-lista" required>
                     <datalist id="artikkelin-luokitus-lista">

--- a/src/clients/artikkelit/interfaces/constants.js
+++ b/src/clients/artikkelit/interfaces/constants.js
@@ -31,7 +31,7 @@ export const searchTypes = [
 // https://wiki.eduuni.fi/display/cscsuorat/7.5+Julkaisutyypit+2021
 export const articleTypesBooks = [
   {
-    value: "A3  - Vertaisarvioitu kirjan tai muun kokoomateoksen osa",
+    value: "A3 - Vertaisarvioitu kirjan tai muun kokoomateoksen osa",
     text: ""
   },
   {
@@ -332,7 +332,7 @@ export const sciences = [
     text: ""
   },
   {
-    value: "3 - Lääke- ja terveystieteet - 3111 -Biolääketieteet",
+    value: "3 - Lääke- ja terveystieteet - 3111 - Biolääketieteet",
     text: ""
   },
   {


### PR DESCRIPTION
Fixed typos mentioned in MUU-184 and MUU-187.

Datalist dropdown unchanged, despite being requested in MUU-187. Datalist elements nigh impossible to edit with traditional means. Would require external libraries or extensive code to re-write the entire functionality of a datalist element.

Dropdown item texts work well in Firefox. The issue concerns Chrome, where texts overflow the dropdown area.