### PR TITLE
MUU-405 + MUU-439

### DIFF
--- a/src/clients/artikkelit/artikkelit.html
+++ b/src/clients/artikkelit/artikkelit.html
@@ -245,14 +245,14 @@
                 </div>
               </fieldset>
 
-              <!-- FIELDSET: artikkelin haku-->
+              <!-- FIELDSET: artikkelin perustietojen lisääminen -->
               <fieldset>
                 <legend>Artikkelin tiedot</legend>
 
                 <div id="numeron-vuosi-wrap" class="full-width">
                   <div class="Input">
                     <label class="bold-text" for="numeron-vuosi">Vuosi:</label>
-                    <input type="text" id="numeron-vuosi" name="numeron-vuosi" size="6" required="true" title="">
+                    <input type="number" id="numeron-vuosi" name="numeron-vuosi" min="1750" max="2050" minlength="4" maxlength="4" size="6" required="true" title="">
                   </div>
                 </div>
 

--- a/src/clients/artikkelit/artikkelit.js
+++ b/src/clients/artikkelit/artikkelit.js
@@ -66,8 +66,11 @@ function sourceTypeChange(event) {
 
   if (sourceType === 'book') {
     document.getElementById(`numeron-vuosi-wrap`).style.display = 'none';
+    document.getElementById(`numeron-vuosi`).value = '';
     document.getElementById(`numeron-vol-wrap`).style.display = 'none';
+    document.getElementById(`numeron-vol`).value = '';
     document.getElementById(`numeron-numero-wrap`).style.display = 'none';
+    document.getElementById(`numeron-numero`).value = '';
     document.getElementById(`artikkelin-osasto-toistuva-wrap`).style.display = 'none';
     document.getElementById(`lehden-tunniste-label`).innerHTML = 'ISBN:';
     document.getElementById('artikkelin-osasto-toistuva').value = '';


### PR DESCRIPTION
- The input in 'Vuosi' input field is now checked: the inputted year for an article in journal should be in between defined timeframe
- The values for 'Vuosi', 'Vol' and 'Number' fields are now cleared when source type is changed from journal to book