### PR TITLE
MUU-345

### DIFF
--- a/src/clients/viewer/fileHandling.js
+++ b/src/clients/viewer/fileHandling.js
@@ -26,15 +26,25 @@ window.downloadFile = function (event) {
   idbGetLogs(sequence)
     .then((data) => {
 
-      if (data.logItemType !== 'MERGE_LOG') {
-        throw new Error('Wrong log item type (should be MERGE_LOG)');
+      if (data.logItemType !== 'MERGE_LOG' && data.logItemType !== 'MATCH_LOG') {
+        throw new Error('Wrong log item type (should be MERGE_LOG or MATCH_LOG)');
       }
 
-      setPreferred(data.preference);
-      setIncomingRecord(data.incomingRecord);
-      setMelindaRecord(data.databaseRecord);
-      setMergedRecord(data.mergedRecord);
-      setCreationTime(data.creationTime);
+      if (data.logItemType === 'MERGE_LOG') {
+        setPreferred(data.preference);
+        setIncomingRecord(data.incomingRecord);
+        setMelindaRecord(data.databaseRecord);
+        setMergedRecord(data.mergedRecord);
+        setCreationTime(data.creationTime);
+      }
+
+      if (data.logItemType === 'MATCH_LOG') {
+        setIncomingRecord(data.incomingRecord);
+        setMatchedRecord(data.matchResult[0]);
+        setMatcherReports(data.matchResult[0]);
+        setCreationTime(data.creationTime);
+      }
+
       doDownload(JSON.stringify(recordObject));
       showSnackbar({style: 'success', text: 'Tiedosto ladattiin onnistuneesti laitteellesi!'});
     })
@@ -62,6 +72,18 @@ window.downloadFile = function (event) {
 
   function setMergedRecord(record) {
     recordObject.mergedRecord = record;
+  }
+
+  function setMatchedRecord(result) {
+    recordObject.matchedRecord = result?.candidate.record ?? {};
+  }
+
+  function setMatcherReports(result) {
+    recordObject.matcherReport = {};
+    recordObject.matcherReport.melindaId = result?.candidate.id;
+    recordObject.matcherReport.action = result?.action;
+    recordObject.matcherReport.probability = result?.probability;
+    recordObject.matcherReport.preferenceRecord = result?.preference;
   }
 
   function setCreationTime(time) {

--- a/src/clients/viewer/fileHandling.js
+++ b/src/clients/viewer/fileHandling.js
@@ -21,6 +21,7 @@ window.downloadFile = function (event) {
 
   const correlationId = document.querySelector(`#viewer #id`).value;
   const sequence = document.querySelector(`#viewer #sequence`).value;
+  const logType = document.querySelector(`#viewer #logType`).value;
   const recordObject = new Object();
 
   idbGetLogs(sequence)
@@ -30,19 +31,25 @@ window.downloadFile = function (event) {
         throw new Error('Wrong log item type (should be MERGE_LOG or MATCH_LOG)');
       }
 
+      if (correlationId !== data.correlationId || sequence !== data.blobSequence.toString() || logType !== data.logItemType) {
+        throw new Error('Id, sequence or log type do not match in UI and data');
+      }
+
+      setCorrelationId(data.correlationId);
+      setBlobSequence(data.blobSequence.toString());
+      setLogItemType(data.logItemType);
+      setCreationTime(data.creationTime);
+      setIncomingRecord(data.incomingRecord);
+
       if (data.logItemType === 'MERGE_LOG') {
         setPreferred(data.preference);
-        setIncomingRecord(data.incomingRecord);
         setMelindaRecord(data.databaseRecord);
         setMergedRecord(data.mergedRecord);
-        setCreationTime(data.creationTime);
       }
 
       if (data.logItemType === 'MATCH_LOG') {
-        setIncomingRecord(data.incomingRecord);
-        setMatchedRecord(data.matchResult[0]);
-        setMatcherReports(data.matchResult[0]);
-        setCreationTime(data.creationTime);
+        setMatchResults(data.matchResult);
+        setMatcherReports(data.matcherReports);
       }
 
       doDownload(JSON.stringify(recordObject));
@@ -52,6 +59,22 @@ window.downloadFile = function (event) {
       console.log('Problem getting or setting log data while creating record object: ', error);
       showSnackbar({style: 'error', text: 'Tiedostoa ei valitettavasti pystytty lataamaan'});
     });
+
+  function setCorrelationId(id) {
+    recordObject.correlationId = id;
+  }
+
+  function setBlobSequence(sequence) {
+    recordObject.blobSequence = sequence;
+  }
+
+  function setLogItemType(logType) {
+    recordObject.logItemType = logType;
+  }
+
+  function setCreationTime(time) {
+    recordObject.creationTime = time;
+  }
 
   function setPreferred(preference) {
     if (preference.recordName === 'databaseRecord') {
@@ -74,34 +97,26 @@ window.downloadFile = function (event) {
     recordObject.mergedRecord = record;
   }
 
-  function setMatchedRecord(result) {
-    if (result === undefined) {
-      recordObject.matchedRecord = {};
+  function setMatchResults(results) {
+    if (results === undefined) {
+      recordObject.matchResult = 'No match results'
       return;
     }
 
-    recordObject.matchedRecord = result.candidate.record
+    recordObject.matchResults = results;
   }
 
-  function setMatcherReports(result) {
-    if (result === undefined) {
-      recordObject.matcherReport = 'No match result'
+  function setMatcherReports(reports) {
+    if (reports === undefined) {
+      recordObject.matcherReports = 'No matcher reports'
       return;
     }
 
-    recordObject.matcherReport = {};
-    recordObject.matcherReport.melindaId = result.candidate.id;
-    recordObject.matcherReport.action = result.action;
-    recordObject.matcherReport.probability = result.probability;
-    recordObject.matcherReport.preferenceRecord = result.preference;
-  }
-
-  function setCreationTime(time) {
-    recordObject.creationTime = time;
+    recordObject.matcherReports = reports;
   }
 
   function doDownload(fileContent) {
-    const fileName = `${correlationId}_${sequence}.json`;
+    const fileName = `${correlationId}_${sequence}_${logType}.json`;
 
     const linkElement = document.createElement('a');
     linkElement.download = fileName;

--- a/src/clients/viewer/fileHandling.js
+++ b/src/clients/viewer/fileHandling.js
@@ -75,15 +75,25 @@ window.downloadFile = function (event) {
   }
 
   function setMatchedRecord(result) {
-    recordObject.matchedRecord = result?.candidate.record ?? {};
+    if (result === undefined) {
+      recordObject.matchedRecord = {};
+      return;
+    }
+
+    recordObject.matchedRecord = result.candidate.record
   }
 
   function setMatcherReports(result) {
+    if (result === undefined) {
+      recordObject.matcherReport = 'No match result'
+      return;
+    }
+
     recordObject.matcherReport = {};
-    recordObject.matcherReport.melindaId = result?.candidate.id;
-    recordObject.matcherReport.action = result?.action;
-    recordObject.matcherReport.probability = result?.probability;
-    recordObject.matcherReport.preferenceRecord = result?.preference;
+    recordObject.matcherReport.melindaId = result.candidate.id;
+    recordObject.matcherReport.action = result.action;
+    recordObject.matcherReport.probability = result.probability;
+    recordObject.matcherReport.preferenceRecord = result.preference;
   }
 
   function setCreationTime(time) {

--- a/src/clients/viewer/viewer.js
+++ b/src/clients/viewer/viewer.js
@@ -217,6 +217,8 @@ window.doFetch = function (event = undefined, id = '', sequence = 0, logType = '
 
   if (logType === 'MATCH_LOG') {
     col3.style.display = 'none';
+    enableElement(downloadFileButton);
+
     getMatchLog(id)
       .then(logs => setDataToIndexDB(logs, sequence))
       .catch(error => {


### PR DESCRIPTION
- Match logs can now be downloaded as JSON files from Viewer log browsing. 
- Some minor data additions to merge log files were also made.
- Download is now supported for MERGE_LOGs and MATCH_LOGs.

