### PR TITLE
Muu 435: Preactivating edit mode for fields editable item in edit mode if it was clicked on the general view when activating edit mode

### DIFF
--- a/src/clients/common/marc-record-ui.js
+++ b/src/clients/common/marc-record-ui.js
@@ -86,8 +86,8 @@ function addField(div, field, decorator = null) {
   if (field.value) {
     addValue(row, field.value);
   } else if (field.subfields) {
-    for (const subfield of field.subfields) {
-      addSubfield(row, subfield);
+    for (const [index, subfield] of field.subfields.entries()) {
+      addSubfield(row, subfield, index);
     }
   }
 
@@ -116,19 +116,19 @@ function addField(div, field, decorator = null) {
     row.appendChild(makeSpan('value', value));
   }
 
-  function addSubfield(row, subfield) {
+  function addSubfield(row, subfield, index = 0) {
     const span = makeSpan('subfield');
-    span.appendChild(makeSubfieldCode(subfield.code));
-    span.appendChild(makeSubfieldData(subfield.value));
+    span.appendChild(makeSubfieldCode(subfield.code, index));
+    span.appendChild(makeSubfieldData(subfield.value, index));
     row.appendChild(span);
   }
 
-  function makeSubfieldCode(code) {
-    return makeSpan('code', code);
+  function makeSubfieldCode(code, index = 0) {
+    return makeSpan('code', code, null, index);
   }
 
-  function makeSubfieldData(value) {
-    return makeSpan('value', value);
+  function makeSubfieldData(value, index = 0) {
+    return makeSpan('value', value, null, index);
   }
 }
 
@@ -141,9 +141,10 @@ function makeDiv(className, value) {
   return div;
 }
 
-function makeSpan(className, text, html) {
+function makeSpan(className, text, html, index = 0) {
   const span = document.createElement('span');
   span.setAttribute('class', className);
+  span.setAttribute('index', index);
   if (text) {
     span.textContent = text;
   } else if (html) {
@@ -216,8 +217,8 @@ export function editField(field, original = null, preActivatedEditSection = null
 
   // if field contains "subfields" and not "value"
   } else if (field.subfields) {
-    for (const subfield of field.subfields) {
-      createSubfield(subfields, subfield);
+    for (const [index, subfield] of field.subfields.entries()) {
+      createSubfield(subfields, subfield, preActivatedEditSection, index);
     }
 
     //*
@@ -228,20 +229,37 @@ export function editField(field, original = null, preActivatedEditSection = null
 
     /**/
   }
-  function preactivateEditIfRequested(preActivatedEditSection, inputClassName ,input){
-    if(preActivatedEditSection !== null && inputClassName === preActivatedEditSection){
-      input.focus();
-    }
+  
+}
+
+function preactivateEditIfRequested(preActivatedEditSection, inputClassName , input, index = 0){
+  if(preActivatedEditSection !== null){
+    console.log('Comparing: '+inputClassName+' with ' +preActivatedEditSection.class);
+    console.log('Comparing: '+index + ' with '+ preActivatedEditSection.index);
+  }
+  
+  if(preActivatedEditSection !== null && inputClassName === preActivatedEditSection.class && index === preActivatedEditSection.index){
+    console.log('Found correct item at: '+preActivatedEditSection.class +' in index '+ preActivatedEditSection.index);
+    input.focus();
   }
 }
 
-function createSubfield(parent, subfield) {
+function createSubfield(parent, subfield, preActivatedEditSection, index = 0) {
   const row = document.createElement('div');
   row.classList.add('subfield');
   row.appendChild(removeButton());
-  row.appendChild(createInput('code', 'code', subfield.code));
-  row.appendChild(createInput('value', 'value', subfield.value));
+
+  const codeInput = createInput('code', 'code', subfield.code);
+  const valueInput = createInput('value', 'value', subfield.value);
+
+  row.appendChild(codeInput);
+  row.appendChild(valueInput);
+
   parent.appendChild(row);
+
+  preactivateEditIfRequested(preActivatedEditSection, 'code', codeInput, index);
+  preactivateEditIfRequested(preActivatedEditSection, 'value', valueInput, index);
+
   return row;
 
   function removeButton() {

--- a/src/clients/common/marc-record-ui.js
+++ b/src/clients/common/marc-record-ui.js
@@ -159,7 +159,7 @@ function makeSpan(className, text, html, index = 0) {
 
 let editing = null;
 
-export function editField(field, original = null, preActivatedEditSection = null) {
+export function editField(field, original = null, elementToPreactivate = null) {
   // Edit-ohje: https://marc21.kansalliskirjasto.fi/bib/05X-08X.htm#050
 
   editing = field;
@@ -187,20 +187,20 @@ export function editField(field, original = null, preActivatedEditSection = null
   tag.innerHTML = '';
   const tagInput = createInput('tag', 'tag', field.tag);
   tag.appendChild(tagInput);
-  preactivateEditIfRequested(preActivatedEditSection, 'tag', tagInput);
+  preactivateEdit(elementToPreactivate, 'tag', tagInput);
   
 
   const ind1 = document.querySelector('#fieldEditDlg #ind1');
   ind1.innerHTML = '';
   const ind1Input = createInput('ind1', 'inds', field.ind1);
   ind1.appendChild(ind1Input);
-  preactivateEditIfRequested(preActivatedEditSection, 'ind1' ,ind1Input);
+  preactivateEdit(elementToPreactivate, 'ind1' ,ind1Input);
 
   const ind2 = document.querySelector('#fieldEditDlg #ind2');
   ind2.innerHTML = '';
   const ind2Input = createInput('ind2', 'inds', field.ind2);
   ind2.appendChild(ind2Input);
-  preactivateEditIfRequested(preActivatedEditSection, 'ind2' ,ind2Input);
+  preactivateEdit(elementToPreactivate, 'ind2' ,ind2Input);
 
   const subfields = document.querySelector('#fieldEditDlg #fieldlist');
   subfields.innerHTML = '';
@@ -213,12 +213,12 @@ export function editField(field, original = null, preActivatedEditSection = null
     value.innerHTML = 'Arvo:';
     const valueInput = createInput('value', 'value', field.value);
     value.appendChild(valueInput);
-    preactivateEditIfRequested(preActivatedEditSection, 'value' ,valueInput);
+    preactivateEdit(elementToPreactivate, 'value' ,valueInput);
 
   // if field contains "subfields" and not "value"
   } else if (field.subfields) {
     for (const [index, subfield] of field.subfields.entries()) {
-      createSubfield(subfields, subfield, preActivatedEditSection, index);
+      createSubfield(subfields, subfield, elementToPreactivate, index);
     }
 
     //*
@@ -232,19 +232,14 @@ export function editField(field, original = null, preActivatedEditSection = null
   
 }
 
-function preactivateEditIfRequested(preActivatedEditSection, inputClassName , input, index = 0){
-  if(preActivatedEditSection !== null){
-    console.log('Comparing: '+inputClassName+' with ' +preActivatedEditSection.class);
-    console.log('Comparing: '+index + ' with '+ preActivatedEditSection.index);
-  }
-  
-  if(preActivatedEditSection !== null && inputClassName === preActivatedEditSection.class && index === preActivatedEditSection.index){
-    console.log('Found correct item at: '+preActivatedEditSection.class +' in index '+ preActivatedEditSection.index);
+function preactivateEdit(elementToPreactivate, inputClassName , input, index = 0){
+  if(elementToPreactivate && inputClassName && input && inputClassName === elementToPreactivate.class && index === elementToPreactivate.index){
+    //console.log(`Found correct item at: ${elementToPreactivate.class} in index ${elementToPreactivate.index}`);
     input.focus();
   }
 }
 
-function createSubfield(parent, subfield, preActivatedEditSection, index = 0) {
+function createSubfield(parent, subfield, elementToPreactivate, index = 0) {
   const row = document.createElement('div');
   row.classList.add('subfield');
   row.appendChild(removeButton());
@@ -257,8 +252,8 @@ function createSubfield(parent, subfield, preActivatedEditSection, index = 0) {
 
   parent.appendChild(row);
 
-  preactivateEditIfRequested(preActivatedEditSection, 'code', codeInput, index);
-  preactivateEditIfRequested(preActivatedEditSection, 'value', valueInput, index);
+  preactivateEdit(elementToPreactivate, 'code', codeInput, index);
+  preactivateEdit(elementToPreactivate, 'value', valueInput, index);
 
   return row;
 

--- a/src/clients/common/marc-record-ui.js
+++ b/src/clients/common/marc-record-ui.js
@@ -102,13 +102,13 @@ function addField(div, field, decorator = null) {
 
   function addInd(row, ind1, ind2) {
     const span = makeSpan('inds');
-    add(span, ind1);
-    add(span, ind2);
+    add(span, ind1, 'ind1');
+    add(span, ind2, 'ind2');
     row.appendChild(span);
 
-    function add(span, ind) {
+    function add(span, ind, className = 'ind') {
       const value = ind && ind.trim() || '&nbsp;';
-      span.appendChild(makeSpan('ind', null, value));
+      span.appendChild(makeSpan(className, null, value));
     }
   }
 
@@ -158,7 +158,7 @@ function makeSpan(className, text, html) {
 
 let editing = null;
 
-export function editField(field, original = null) {
+export function editField(field, original = null, preActivatedEditSection = null) {
   // Edit-ohje: https://marc21.kansalliskirjasto.fi/bib/05X-08X.htm#050
 
   editing = field;
@@ -184,15 +184,22 @@ export function editField(field, original = null) {
 
   const tag = document.querySelector('#fieldEditDlg #tag');
   tag.innerHTML = '';
-  tag.appendChild(createInput('tag', 'tag', field.tag));
+  const tagInput = createInput('tag', 'tag', field.tag);
+  tag.appendChild(tagInput);
+  preactivateEditIfRequested(preActivatedEditSection, 'tag', tagInput);
+  
 
   const ind1 = document.querySelector('#fieldEditDlg #ind1');
   ind1.innerHTML = '';
-  ind1.appendChild(createInput('ind1', 'inds', field.ind1));
+  const ind1Input = createInput('ind1', 'inds', field.ind1);
+  ind1.appendChild(ind1Input);
+  preactivateEditIfRequested(preActivatedEditSection, 'ind1' ,ind1Input);
 
   const ind2 = document.querySelector('#fieldEditDlg #ind2');
   ind2.innerHTML = '';
-  ind2.appendChild(createInput('ind2', 'inds', field.ind2));
+  const ind2Input = createInput('ind2', 'inds', field.ind2);
+  ind2.appendChild(ind2Input);
+  preactivateEditIfRequested(preActivatedEditSection, 'ind2' ,ind2Input);
 
   const subfields = document.querySelector('#fieldEditDlg #fieldlist');
   subfields.innerHTML = '';
@@ -203,7 +210,9 @@ export function editField(field, original = null) {
   // if field contains "value" and not "subfields"
   if (field.value) {
     value.innerHTML = 'Arvo:';
-    value.appendChild(createInput('value', 'value', field.value));
+    const valueInput = createInput('value', 'value', field.value);
+    value.appendChild(valueInput);
+    preactivateEditIfRequested(preActivatedEditSection, 'value' ,valueInput);
 
   // if field contains "subfields" and not "value"
   } else if (field.subfields) {
@@ -218,6 +227,11 @@ export function editField(field, original = null) {
     });
 
     /**/
+  }
+  function preactivateEditIfRequested(preActivatedEditSection, inputClassName ,input){
+    if(preActivatedEditSection !== null && inputClassName === preActivatedEditSection){
+      input.focus();
+    }
   }
 }
 

--- a/src/clients/muuntaja/muuntaja.js
+++ b/src/clients/muuntaja/muuntaja.js
@@ -299,25 +299,24 @@ function onFieldClick(event, field) {
   //console.log("Click", field)
   
   if (editmode) {
-    //returns sub element clicked, if no specific subelement it returns just row row-fromBase
-    //span uses classname as class
-    //var subElementRequested = event.originalTarget.attributes.class.nodeValue;
-    var subElement = {'class':'', 'index':0}
+
+    //returns sub element of the field clicked, if no specific subelement it returns just row row-fromBase
+    //span uses as class classname/id
+    var subElement = null;
     try {
+      subElement = {};
       subElement.class = event.originalTarget.attributes.class.nodeValue;
       subElement.index = parseInt(event.originalTarget.attributes.index.nodeValue);
     } catch (error) {
-      console.error('Getting sub element encountered error: '+error);
+      console.error(`Getting field sub element encountered error: ${error}`);
+      subElement = null;
     }
     //make sure only certain values can be auto edit focus requested
-    //if not correct later expect null
-    if(!isSubFieldAcceptable(subElement.class)){
-        console.log(`Sub element ${subElement.class} is not acceptable`);
+    //if not correct later expects null and does nothing
+    if(subElement && !isSubElementAcceptable(subElement.class)){
+        console.log(`Fields sub element ${subElement.class} is not acceptable for pre activation`);
         subElement = null;
-      }
-      else{
-        console.log('Requesting specific field to edit automatically: ' + subElement.class + ' with index ' + subElement.index);
-      }
+    }
 
     editField(getContent(field), getOriginal(field), subElement);
   } else {
@@ -338,7 +337,7 @@ function onFieldClick(event, field) {
 
     doTransform();
   }
-  function isSubFieldAcceptable(elementRequested){
+  function isSubElementAcceptable(elementRequested){
     switch (elementRequested){
       case 'tag':
       case 'ind1':

--- a/src/clients/muuntaja/muuntaja.js
+++ b/src/clients/muuntaja/muuntaja.js
@@ -297,8 +297,22 @@ function decorateField(div, field) {
 
 function onFieldClick(event, field) {
   //console.log("Click", field)
+  
   if (editmode) {
-    editField(getContent(field), getOriginal(field));
+    //returns sub element clicked, if no specific subelement it returns just row row-fromBase
+    //span uses classname as class
+    var subElementRequested = event.originalTarget.attributes.class.nodeValue;
+    //make sure only certain values can be auto edit focus requested
+    //if not correct later expect null
+    if(!isSubFieldAcceptable(subElementRequested)){
+        console.log(`Sub element ${subElementRequested} is not acceptable`);
+        subElementRequested = null;
+      }
+      else{
+        console.log('Requesting specific field to edit automatically: ' + subElementRequested);
+      }
+
+    editField(getContent(field), getOriginal(field), subElementRequested);
   } else {
     toggleField(field);
   }
@@ -316,6 +330,18 @@ function onFieldClick(event, field) {
     }
 
     doTransform();
+  }
+  function isSubFieldAcceptable(elementRequested){
+    switch (elementRequested){
+      case 'tag':
+      case 'ind1':
+      case 'ind2':
+      case 'code':
+      case 'value':
+        return true;
+      default:
+        return false;
+    }
   }
 }
 

--- a/src/clients/muuntaja/muuntaja.js
+++ b/src/clients/muuntaja/muuntaja.js
@@ -301,18 +301,25 @@ function onFieldClick(event, field) {
   if (editmode) {
     //returns sub element clicked, if no specific subelement it returns just row row-fromBase
     //span uses classname as class
-    var subElementRequested = event.originalTarget.attributes.class.nodeValue;
+    //var subElementRequested = event.originalTarget.attributes.class.nodeValue;
+    var subElement = {'class':'', 'index':0}
+    try {
+      subElement.class = event.originalTarget.attributes.class.nodeValue;
+      subElement.index = parseInt(event.originalTarget.attributes.index.nodeValue);
+    } catch (error) {
+      console.error('Getting sub element encountered error: '+error);
+    }
     //make sure only certain values can be auto edit focus requested
     //if not correct later expect null
-    if(!isSubFieldAcceptable(subElementRequested)){
-        console.log(`Sub element ${subElementRequested} is not acceptable`);
-        subElementRequested = null;
+    if(!isSubFieldAcceptable(subElement.class)){
+        console.log(`Sub element ${subElement.class} is not acceptable`);
+        subElement = null;
       }
       else{
-        console.log('Requesting specific field to edit automatically: ' + subElementRequested);
+        console.log('Requesting specific field to edit automatically: ' + subElement.class + ' with index ' + subElement.index);
       }
 
-    editField(getContent(field), getOriginal(field), subElementRequested);
+    editField(getContent(field), getOriginal(field), subElement);
   } else {
     toggleField(field);
   }


### PR DESCRIPTION
Simply put: what was clicked on field in general view, when creating edit view compare element info to one clicked one, if correct input span requests focus. 
 
If in edit mode field was clicked and it was deemed to be on ok list when edit window is opened check  if created span item is corresponding with the item clicked. If so request focus and thus cursor/edit mode is activated for it. 
Changed so sub fields spans record attribute index along side of the class attribute. Probed from onfield clicked event the class and index of the event target. 

Tested to be working locally as wanted.