### PR TITLE
Muu 434: Source and Base data should not be the same

### DIFF
--- a/src/clients/muuntaja/muuntaja.js
+++ b/src/clients/muuntaja/muuntaja.js
@@ -316,11 +316,8 @@ window.doTransform = function (event = undefined) {
   //console.log('Base ID:', baseID);
   console.log('Transforming:', transformed);
 
-  const sourceInput = document.querySelector(`#muuntaja .record-merge-panel #source #ID`);
-  const baseInput = document.querySelector(`#muuntaja .record-merge-panel #base #ID`);
-
-  const sourceID = sourceInput.value;
-  const baseID = baseInput.value;
+  const sourceID = document.querySelector(`#muuntaja .record-merge-panel #source #ID`).value;
+  const baseID = document.querySelector(`#muuntaja .record-merge-panel #base #ID`).value;
 
   //exception, if source and base ids are the same inform user
   if(sourceID === baseID){

--- a/src/clients/muuntaja/muuntaja.js
+++ b/src/clients/muuntaja/muuntaja.js
@@ -322,7 +322,7 @@ window.doTransform = function (event = undefined) {
   const sourceID = sourceInput.value;
   const baseID = baseInput.value;
 
-  //exception, if source and base ids are the same clear the base id and leave source
+  //exception, if source and base ids are the same inform user
   if(sourceID === baseID){
     console.log('Source and base ID:s match. This is not permitted');
     alert('Lähde ja Pohja tietueet eivät voi olla samat');

--- a/src/clients/muuntaja/muuntaja.js
+++ b/src/clients/muuntaja/muuntaja.js
@@ -316,8 +316,18 @@ window.doTransform = function (event = undefined) {
   //console.log('Base ID:', baseID);
   console.log('Transforming:', transformed);
 
-  const sourceID = document.querySelector(`#muuntaja .record-merge-panel #source #ID`).value;
-  const baseID = document.querySelector(`#muuntaja .record-merge-panel #base #ID`).value;
+  const sourceInput = document.querySelector(`#muuntaja .record-merge-panel #source #ID`);
+  const baseInput = document.querySelector(`#muuntaja .record-merge-panel #base #ID`);
+
+  const sourceID = sourceInput.value;
+  const baseID = baseInput.value;
+
+  //exception, if source and base ids are the same clear the base id and leave source
+  if(sourceID === baseID){
+    console.log('Source and base ID:s match. This is not permitted');
+    alert('Lähde ja Pohja tietueet eivät voi olla samat');
+    return;
+  }
 
   if (!transformed.source || sourceID != transformed.source.ID) {
     transformed.source = {ID: sourceID};


### PR DESCRIPTION
Preventing duplicate data by restricting the search with same ID:s. Informing user if this happens.