### PR TITLE
MUU-489: Visible name of kvp profile changed to default

### DIFF
--- a/src/muuntaja/muuntajaRoute.js
+++ b/src/muuntaja/muuntajaRoute.js
@@ -56,7 +56,7 @@ export default function (sruUrl) {
         'e2p': 'E-aineistosta > Painetuksi'
       },
       profile: {
-        'KVP': 'Kirjastoverkkopalvelut',
+        'KVP': 'Oletus',
         'FENNI': 'Fennica'
       },
       defaults: optDefaults


### PR DESCRIPTION
It was requested the 'Kirjastoverkkopalvelut' to be changed into default as it was in the old version of 'muuntaja'.
At some point these could be checked on client side by the key and just thrown translation up there