### PR TITLE
MUU-493/495: better configurable decorators and cursor styling for clickable rows.

### DIFF
--- a/src/clients/common/marc-record-ui.js
+++ b/src/clients/common/marc-record-ui.js
@@ -73,6 +73,7 @@ function addField(div, field, decorator = null, recordDestination = '') {
   decorateField(row, field);
 
   if (onClick) {
+    row.classList.add('clickable');
     row.addEventListener('click', event => onClick(event, field, (original && original[field.id]) ?? field));
   }
 

--- a/src/clients/common/stylesheets/marc.css
+++ b/src/clients/common/stylesheets/marc.css
@@ -26,6 +26,10 @@
   border: 1px dashed var(--color-grey-80)
 }
 
+.marc-record .row.clickable:hover{
+  cursor: pointer;
+}
+
 .marc-record .error {
   background-color: #eba0a060;
   padding: 8px;


### PR DESCRIPTION
Get rid of global decorators, use showRecord from showTransformed. 
Fixes bug where colour coding did not work on fields.
Included MUU-495 where clickable muuntaja marc rows have different cursor, possibly helping to understand user may interact with them 