### PR TITLE
MUU-497/431: exluded marc rows visual update 

### DIFF
--- a/src/clients/common/stylesheets/marc.css
+++ b/src/clients/common/stylesheets/marc.css
@@ -42,6 +42,8 @@
 
 .marc-record .row-excluded {
   opacity: 0.5;
+  text-decoration-line: line-through;
+  text-decoration-color: gray;
 }
 
 .marc-record .row-replaced {


### PR DESCRIPTION
Deleted/disabled marc rows have now additional css feedback for style. Now text content is stricken through with line.