### PR TITLE
MUU-432: Delete field button on editing window

### DIFF
--- a/src/clients/common/marc-record-ui.js
+++ b/src/clients/common/marc-record-ui.js
@@ -7,13 +7,15 @@
 //-----------------------------------------------------------------------------
 //-----------------------------------------------------------------------------
 
+let onDeleteField = null;
 export function showRecord(record, dest, decorator = {}, recordDivName = 'muuntaja', logRecord = true) {
 
   if (logRecord) {
     console.log('Show Record:', record);
   }
 
-  const {replace} = decorator;
+  const {replace, onDelete} = decorator;
+  onDeleteField = onDelete;
 
   // Get div to fill in the fields
   const recordDiv = document.querySelector(`#${recordDivName} .record-merge-panel #${dest} #Record`);
@@ -576,6 +578,13 @@ window.onAddField = function (event) {
 
   setEditSaveButtonActiveState(hasActiveSubFields(subfields) && hasDataChanged(editing));
   return eventHandled(event);
+};
+
+window.onDeleteField = function(event){
+  if(confirm(`Haluatko varmasti poistaa kentän ?`) === true){
+    onDeleteField(event, editing);
+    return editDlgClose(event);
+  }
 };
 
 window.editDlgOK = function (event) {

--- a/src/clients/muuntaja/muuntaja.html
+++ b/src/clients/muuntaja/muuntaja.html
@@ -222,6 +222,10 @@
               <button id="editSaveButton" onclick="return editDlgOK(event)" disabled>Tallenna muutokset</button>
             </div>
 
+            <hr />
+            <div style="display: flex; justify-content: left;">
+              <button id="deleteField" onclick="return onDeleteField(event)">Poista kenttä</button>
+            </div>
           </div>
         </div>
 

--- a/src/clients/muuntaja/muuntaja.html
+++ b/src/clients/muuntaja/muuntaja.html
@@ -223,7 +223,7 @@
             </div>
 
             <hr />
-            <div style="display: flex; justify-content: left;">
+            <div style="display: flex; justify-content: center;">
               <button id="deleteField" onclick="return onDeleteField(event)">Poista kenttä</button>
             </div>
           </div>

--- a/src/clients/muuntaja/muuntaja.js
+++ b/src/clients/muuntaja/muuntaja.js
@@ -483,6 +483,7 @@ function showTransformed(update = undefined) {
   });
   showRecord(result, keys.result, {
     onClick: editmode ? onEditClick : onToggleClick,
+    onDelete: onToggleClick,
     from,
     original,
     exclude: transformed.exclude,
@@ -496,29 +497,6 @@ function showTransformed(update = undefined) {
   function getLookup(fields) {
     return fields.reduce((a, field) => ({...a, [field.id]: field}), {});
   }
-}
-
-function getCustomDecorator(dest, originalDecorator, isEditModeActive = false){
-  //get deep copies to prevent crossreference connections (might be overkill...)
-  const copiedDecorator = getDeepCopyOfObject(originalDecorator);
-  //edit decorators for each as required based on dest
-  switch (dest) {
-    case keys.source:
-      //customise here
-      copiedDecorator.onClick = onToggleClick;
-      break;
-    case keys.base:
-      //customise here
-      copiedDecorator.onClick = onToggleClick;
-      break;
-    case keys.result:
-      copiedDecorator.onClick = isEditModeActive ? onEditClick : onToggleClick;
-      break;
-    default:
-      //use original setup
-      break;
-  }
-  return copiedDecorator;
 }
 
 function notFoundDlgOpen(recordType) {


### PR DESCRIPTION
As requested user may now in editing window delete the field. Uses the toggle field logic so essentially works same as without editing mode active clicking the result field row. Delete action, for now, asks for confirmation.