### PR TITLE
MUU-593: Allow user to select LOWTAG / profile

### DIFF
--- a/src/auth/authRoute.js
+++ b/src/auth/authRoute.js
@@ -31,9 +31,10 @@ export default function (jwtOptions) { // eslint-disable-line no-unused-vars
   }
 
   function create(req, res) {
-    // Strip files
+    logger.debug(`User: ${JSON.stringify(req.user)}`);
     const user = {
       Name: req.user.displayName,
+      Authorization: req.user.authorization,
       Token: generateJwtToken(req.user, jwtOptions)
     };
 


### PR DESCRIPTION
When users log in, there is authorization field containing an array of organizations user can use when making operations. We could send these to client and let user to choose the organization (profile / LOWTAG).