### PR TITLE
MUU-660: note_mongo_uri env var default

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -14,7 +14,7 @@ export const ownAuthzApiKey = readEnvironmentVariable('OWN_AUTHZ_API_KEY');
 export const sruUrl = readEnvironmentVariable('SRU_URL');
 export const fintoUrl = readEnvironmentVariable('FINTO_URL');
 
-export const notificationMongoUri = readEnvironmentVariable('NOTE_MONGO_URI');
+export const notificationMongoUri = readEnvironmentVariable('NOTE_MONGO_URI', {defaultValue: ''});
 
 export const jwtOptions = {
   secretOrPrivateKey: readEnvironmentVariable('JWT_SECRET'),


### PR DESCRIPTION
- adding default value negates any crashes regarding that variable not set with readEnvironmentVariable function
- notifications route already takes into account if uri is not set