### PR TITLE
MUU-676: common "url update" update

### DIFF
--- a/src/clients/merge/common.js
+++ b/src/clients/merge/common.js
@@ -665,13 +665,13 @@ function updateUrlParameters(transformed) {
   const { options, source, base } = transformed;
 
   const urlParamConfigs = [
-    {id:"type", defaultPosition: 1, value:options?.type, isAcative: useProfileType},
-    {id:"profile", defaultPosition: 2,value:options?.profile, isAcative: useProfileType},
-    {id:"baseId", defaultPosition: 4, value:base?.ID, isAcative:true},
-    {id:"sourceId", defaultPosition: 3,value:source?.ID, isAcative:true}
+    {id:"type", defaultPosition: 1, value:options?.type, isActive: useProfileType},
+    {id:"profile", defaultPosition: 2,value:options?.profile, isActive: useProfileType},
+    {id:"baseId", defaultPosition: 4, value:base?.ID, isActive: true},
+    {id:"sourceId", defaultPosition: 3,value:source?.ID, isActive: true}
   ];
   //filer not needed ones out, (those with not value or not active are left out)
-  const filteredParamConfigs = urlParamConfigs.filter(obj => (obj.isAcative && obj.value));
+  const filteredParamConfigs = urlParamConfigs.filter(obj => (obj.isActive && obj.value));
   //order by position
   filteredParamConfigs.sort((a, b) => a.defaultPosition - b.defaultPosition);
   //set param values


### PR DESCRIPTION
- url update now clear url params and resets them, thus clearing any unnessary params

- url params are now in config array that is filtered and ordered 
  - params are now in fixed order and can be reordered with config 
  - I set url param order to follow ui read from left to right top to bottom logic
  -  params with no values still get dropped out and thus ignored in ordering ("skips to next step")