### PR TITLE
Muu-613: Help url naming and client specific help button

### DIFF
--- a/src/clients/common/helpUrl.js
+++ b/src/clients/common/helpUrl.js
@@ -1,0 +1,73 @@
+//****************************************************************************//
+//                                                                            //
+// Melinda Instruction url handler                                            //
+//                                                                            //
+//****************************************************************************//
+
+//TODO: update clients and their help url:s accordingly
+//Empty url will resolve to default
+const helpUrlConfig = {
+    default: "https://www.kiwi.fi/display/melinda/Ohjeet",
+    viewer: "",
+    muuntaja: "https://www.kiwi.fi/display/melinda/Uusi+Muuntaja+-+testiversio",
+    merge: "https://www.kiwi.fi/pages/viewpage.action?pageId=77365409",
+    edit: "",
+    artikkelit: "https://www.kiwi.fi/pages/viewpage.action?pageId=155648846",
+    cyrillux: "https://www.kiwi.fi/display/melinda/Cyrillux-ohjelma%3A+kyrilliikan+translitterointi",
+    poistot: "https://www.kiwi.fi/pages/viewpage.action?pageId=75203830"
+};
+
+export { setOnHelpClicked };
+
+/**
+ * Set to element click behaviour and open clients hep url upon event, set url opening with optional openInNewtab param
+ *
+ * @param {object} paramObj - pass params
+ * @param {String} paramObj.elementId - where to find element to attach click listener
+ * @param {String} paramObj.clientName - client that requires help url
+ * @param {boolean} [paramObj.openInNewTab=true] - how url should be opened, defaults to true
+ */
+function setOnHelpClicked(paramObj) {
+    if (!paramObj || typeof paramObj !== 'object' || Object.keys(paramObj).length <= 0) {
+        throw new Error('Malformed or missing param object on function');
+    }
+    const { elementId, clientName, openInNewTab = true } = paramObj;
+
+    const element = document.getElementById(elementId);
+    if(!element){
+        console.warn('Could not set help button functionality, did not find correct element. Please see elementId given');
+        return;
+    }
+    element.addEventListener('click', function (event) {
+        onHelpClicked(clientName, openInNewTab);
+    });
+}
+
+/**
+ * Default click behaviour of pressing
+ * @param {String} clientName
+ */
+function onHelpClicked(clientName, openInNewTab) {
+    const url = getHelpUrlForClient(clientName);
+    //new tab
+    if (openInNewTab) {
+        window.open(url);
+        return;
+    }
+    //same tab
+    window.location.href = url;
+}
+
+/**
+ * Get help url for client.
+ * @param {String} clientName - what client requests its help url
+ * @returns {String} url to help wiki page
+ */
+function getHelpUrlForClient(clientName) {
+    //check for additional output
+    if (!clientName) {
+        console.warn('Help Url Get did not get client name. See references. Returning default.');
+        return helpUrlConfig.default;
+    }
+    return helpUrlConfig[clientName] !== "" ? helpUrlConfig[clientName] ?? helpUrlConfig.default : helpUrlConfig.default;
+}

--- a/src/clients/common/helpUrl.js
+++ b/src/clients/common/helpUrl.js
@@ -11,10 +11,6 @@ const helpUrlConfig = {
     viewer: "",
     muuntaja: "https://www.kiwi.fi/display/melinda/Uusi+Muuntaja+-+testiversio",
     merge: "https://www.kiwi.fi/pages/viewpage.action?pageId=77365409",
-    edit: "",
-    artikkelit: "https://www.kiwi.fi/pages/viewpage.action?pageId=155648846",
-    cyrillux: "https://www.kiwi.fi/display/melinda/Cyrillux-ohjelma%3A+kyrilliikan+translitterointi",
-    poistot: "https://www.kiwi.fi/pages/viewpage.action?pageId=75203830"
 };
 
 export { setOnHelpClicked };

--- a/src/clients/common/templates/navbar.html
+++ b/src/clients/common/templates/navbar.html
@@ -35,7 +35,7 @@
                   <span class="material-icons">help_outline</span>
                 </div>
                 <div class="nav-link-text outer-link">
-                  Ohjeet
+                  Melinda wiki
                   <div class="nav-link-icon">
                     <span class="material-icons open-in-new">open_in_new</span>
                   </div>

--- a/src/clients/merge/common/common.js
+++ b/src/clients/merge/common/common.js
@@ -19,6 +19,7 @@ import * as transformModule from '/merge/common/transformationHandler.js';
 import * as uiCommonModule from '/merge/common/uiCommonHandler.js';
 import * as uiEditModule from '/merge/common/uiEditHandler.js';
 import * as urlModule from '/merge/common/urlHandler.js';
+import {setOnHelpClicked} from '/common/helpUrl.js';
 
 //-----------------------------------------------------------------------------
 // Exported
@@ -48,10 +49,16 @@ function initCommonModule(data = {}) {
   uiEditModule.init();
   transformModule.init();
   console.log('All modules initialized');
+
+  setup();
 }
 
 //-----------------------------------------------------------------------------
 // Private
 //-----------------------------------------------------------------------------
-
-
+/**
+ * Some general setups
+ */
+function setup(){
+  setOnHelpClicked({elementId:'helpButton', clientName: dataModule.getClientName()});
+}

--- a/src/clients/merge/merge.html
+++ b/src/clients/merge/merge.html
@@ -142,6 +142,7 @@
               onclick="jsonDlgOpen(event)">edit_note</button>
             <button class="material-icons tooltip icon-only" tooltip-text="Uusi"
               onClick="onNewInstance(event)">add</button>
+            <button id="helpButton" class="material-icons tooltip icon-only" tooltip-text="Ohje">help_outline</button>
           </div>
         </div>
 

--- a/src/clients/muuntaja/muuntaja.html
+++ b/src/clients/muuntaja/muuntaja.html
@@ -147,6 +147,7 @@
               onclick="jsonDlgOpen(event)">edit_note</button>
             <button class="material-icons tooltip icon-only" tooltip-text="Uusi"
               onClick="onNewInstance(event)">add</button>
+            <button id="helpButton" class="material-icons tooltip icon-only" tooltip-text="Ohje">help_outline</button>
           </div>
         </div>
 

--- a/src/clients/viewer/viewer.html
+++ b/src/clients/viewer/viewer.html
@@ -214,6 +214,7 @@
               <button id="hideLogInfo" class="material-icons tooltip icon-only inverse"
                 tooltip-text="Piilota lokin lisätiedot" style="display:none"
                 onclick="return hideLogInfo(event)">info</button>
+              <button id="helpButton" class="material-icons tooltip icon-only" tooltip-text="Ohje">help_outline</button>
             </div>
           </div>
 

--- a/src/clients/viewer/viewer.js
+++ b/src/clients/viewer/viewer.js
@@ -20,6 +20,7 @@ import {getMatchLog, getMergeLog} from '/common/rest.js';
 import {unselectDateButtons, oneDayInMs} from './searchModal.js';
 import {checkFile} from './fileHandling.js';
 import {setProtectButton} from './logActions.js';
+import {setOnHelpClicked} from '/common/helpUrl.js';
 
 //-----------------------------------------------------------------------------------------
 // Initialize on page load
@@ -39,6 +40,7 @@ window.initialize = function () {
     accountMenu.classList.add('show');
     const username = document.querySelector(`#accountMenu #username`);
     username.innerHTML = Account.get().Name;
+    setOnHelpClicked({elementId:'helpButton', clientName: 'viewer'});
     showTab('viewer');
     parseUrlParameters();
     doIndexedDbCheck();


### PR DESCRIPTION
- General header "ohje" label change to "Melinda wiki".
- functionality to add help button to client "ToolBar"
  - add button to html in desired place, add script import to client, add script call to client init
  - functionality made to be easy to maintain
    - url config in json variable within script
    - empty url or bad key falls back to default url
    - you can just import the script and set it to listen element with id
    - url open style can be configured, defaults to same behaviour as headers general link